### PR TITLE
With HttpFilter in Management context workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.2</version>
+		<version>2.5.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/src/main/java/com/example/traceforbidden1/TraceHttpBlockedManagementConfiguration.java
+++ b/src/main/java/com/example/traceforbidden1/TraceHttpBlockedManagementConfiguration.java
@@ -1,60 +1,16 @@
 package com.example.traceforbidden1;
 
-import java.io.IOException;
-
-import javax.servlet.DispatcherType;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpFilter;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
+import org.springframework.context.annotation.Import;
 
 @ManagementContextConfiguration
 @ConditionalOnManagementPort(ManagementPortType.DIFFERENT)
 @ConditionalOnWebApplication(type = Type.SERVLET)
+@Import({org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration.class})
 public class TraceHttpBlockedManagementConfiguration {
 
-    @Bean
-    NoTraceHttpMethodBodyFilter notraceHttpFilter() {
-        return new NoTraceHttpMethodBodyFilter();
-    }
-
-    @Bean
-    public FilterRegistrationBean<NoTraceHttpMethodBodyFilter> managementNoTraceFilterRegistrationBean(
-        final NoTraceHttpMethodBodyFilter filter) {
-        // Tests were made, without this explicit registration in ManagementContext when different port is
-        // launched
-        // the filter is not called at all
-        final FilterRegistrationBean<NoTraceHttpMethodBodyFilter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(filter);
-        registrationBean.addUrlPatterns("/*");
-        registrationBean.setDispatcherTypes(DispatcherType.ERROR);
-        return registrationBean;
-    }
-
-    static class NoTraceHttpMethodBodyFilter extends HttpFilter {
-
-        private static final long serialVersionUID = -5148586916028111963L;
-
-        @Override
-        protected void doFilter(final HttpServletRequest request, final HttpServletResponse response,
-            final FilterChain chain) throws IOException, ServletException {
-            if (HttpMethod.TRACE.toString().equals(request.getMethod())) {
-                response.sendError(HttpStatus.METHOD_NOT_ALLOWED.value(), "TRACE not allowed");
-            } else {
-                chain.doFilter(request, response);
-            }
-        }
-
-    }
 }

--- a/src/main/java/com/example/traceforbidden1/TraceHttpBlockedManagementConfiguration.java
+++ b/src/main/java/com/example/traceforbidden1/TraceHttpBlockedManagementConfiguration.java
@@ -1,0 +1,60 @@
+package com.example.traceforbidden1;
+
+import java.io.IOException;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+@ManagementContextConfiguration
+@ConditionalOnManagementPort(ManagementPortType.DIFFERENT)
+@ConditionalOnWebApplication(type = Type.SERVLET)
+public class TraceHttpBlockedManagementConfiguration {
+
+    @Bean
+    NoTraceHttpMethodBodyFilter notraceHttpFilter() {
+        return new NoTraceHttpMethodBodyFilter();
+    }
+
+    @Bean
+    public FilterRegistrationBean<NoTraceHttpMethodBodyFilter> managementNoTraceFilterRegistrationBean(
+        final NoTraceHttpMethodBodyFilter filter) {
+        // Tests were made, without this explicit registration in ManagementContext when different port is
+        // launched
+        // the filter is not called at all
+        final FilterRegistrationBean<NoTraceHttpMethodBodyFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(filter);
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setDispatcherTypes(DispatcherType.ERROR);
+        return registrationBean;
+    }
+
+    static class NoTraceHttpMethodBodyFilter extends HttpFilter {
+
+        private static final long serialVersionUID = -5148586916028111963L;
+
+        @Override
+        protected void doFilter(final HttpServletRequest request, final HttpServletResponse response,
+            final FilterChain chain) throws IOException, ServletException {
+            if (HttpMethod.TRACE.toString().equals(request.getMethod())) {
+                response.sendError(HttpStatus.METHOD_NOT_ALLOWED.value(), "TRACE not allowed");
+            } else {
+                chain.doFilter(request, response);
+            }
+        }
+
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration=com.example.traceforbidden1.TraceHttpBlockedManagementConfiguration
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+management.server.port=8081


### PR DESCRIPTION
This HttpFilter is a workarounf to avoid leaking of information in Actuator endpoint when deployed in different port than main.